### PR TITLE
github/ci: Test/lint project with no enabled tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ jobs:
         with:
           args: --build-tags dev
 
+  lint-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+
   test:
     strategy:
       matrix:
@@ -38,3 +48,20 @@ jobs:
           go test -tags dev -cover -coverprofile coverage.txt -race -v ./...
 
       - uses: codecov/codecov-action@v3
+
+  test-prod:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ["1.18"]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: "test"
+        run: |
+          go test -tags -race -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- github/ci: Test/lint project with no enabled tag
+
 ## [1.0.0] - 2022-05-08
 ### Added
 - This CHANGELOG file to hopefully serve as an evolving example of a


### PR DESCRIPTION
That enables testing of a project version that will run in production

<!-- Reference to issues related with this PR -->
Related to #4 

# Check list

<!-- Did you update CHANGELOG.md with this PR changes? -->
- [x] Update CHANGELOG.md
